### PR TITLE
docs: Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @eu-digital-green-certificates/dgca-issuance-service-members
+* @eu-digital-green-certificates/dgca-verifier-service-members


### PR DESCRIPTION
Fix reference to wrong github team