### PR TITLE
docs: Fix URLs in dgca-verifier-service doc

### DIFF
--- a/docs/dgca-verifier-service.md
+++ b/docs/dgca-verifier-service.md
@@ -10,12 +10,12 @@ A general overview of how the different member state backends work together, can
 ![DGCA overview](dgca_overview.png "DGCA Overview")
 
 As you can see in the picture, each member state backend provides the services for it's own applications (e.g. verifier, issuer and wallet).
-The member state synchronises the validation certificates over the [DGCGateway](https://https://github.com/eu-digital-green-certificates/dgc-gateway).
+The member state synchronises the validation certificates over the [DGCGateway](https://github.com/eu-digital-green-certificates/dgc-gateway).
 
 ### Purpose and functionality of the DGCA-Verifier-Service
-The verifier service basically caches the public keys that are distributed through the [DGCG](https://https://github.com/eu-digital-green-certificates/dgc-gateway) to the member states backends. 
+The verifier service basically caches the public keys that are distributed through the [DGCG](https://github.com/eu-digital-green-certificates/dgc-gateway) to the member states backends. 
 The service provides the Trust List of certificates for the verifier apps. The apps can get the list to update their key store via an api. 
-To have an actual trust list the verifier service periodically polls the [DGCG](https://https://github.com/eu-digital-green-certificates/dgc-gateway) 
+To have an actual trust list the verifier service periodically polls the [DGCG](https://github.com/eu-digital-green-certificates/dgc-gateway) 
 for the actual trust list. 
 
 In the git repository you will find two implementations of that download functionality: 
@@ -53,4 +53,4 @@ You can than put the file in the openapi viewer of your choice. ([editor.swagger
 ### Further Information
 Further information can be found at [ec.europa.eu/health](https://ec.europa.eu/health/ehealth/covid-19_en)  
 Especially at [Volume 4: Digital Green Certificate Applications](https://ec.europa.eu/health/sites/default/files/ehealth/docs/digital-green-certificates_v4_en.pdf)  
-And the github repository of the [DGCG](https://https://github.com/eu-digital-green-certificates/dgc-gateway)
+And the github repository of the [DGCG](https://github.com/eu-digital-green-certificates/dgc-gateway)


### PR DESCRIPTION
Remove the repetition of https:// in some of the urls in the document